### PR TITLE
Make `offline-detection/main.py` Streamlit compatible

### DIFF
--- a/offline-detection/execute_main.ipynb
+++ b/offline-detection/execute_main.ipynb
@@ -1,0 +1,165 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "id": "8fa9a41a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import importlib\n",
+    "\n",
+    "BASE_DIR = Path.cwd().resolve()\n",
+    "MODULE_PATH = BASE_DIR.parent / \"offline-detection\" / \"main.py\"\n",
+    "\n",
+    "offline_detection = importlib.machinery.SourceFileLoader(\n",
+    "    \"offline-detection\", str(MODULE_PATH)\n",
+    ").load_module()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "id": "2626b756",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "def msg_callback(msg, end=None):\n",
+    "\tprint(msg)\n",
+    "\ttime.sleep(1)\n",
+    "\n",
+    "\tif end is True: print(\"Done!\")\n",
+    "\n",
+    "def handle_report(news, **kwargs):\n",
+    "\tglobal predictions\n",
+    "\tpredictions = news[\"predictions\"]\n",
+    "\n",
+    "\tbardata = np.unique(predictions, return_counts=True)\n",
+    "\tbar = plt.bar(bardata[0], bardata[1])\n",
+    "\n",
+    "\tplt.bar_label(bar)\n",
+    "\tplt.xticks(ticks=[-1, 0, 1, 2], labels=[None, \"Normal\", \"Anomaly\", None])\n",
+    "\tplt.title(\"Predictions of the pipeline\")\n",
+    "\tplt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "id": "e8aa131f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "Starting pipeline execution...\n",
+      "\n",
+      "\n",
+      "\n",
+      "Preprocessing...\n",
+      "\n",
+      "\n",
+      "\n",
+      "Finished preprocessing.\n",
+      "\n",
+      "\n",
+      "\n",
+      "Obtaining model...\n",
+      "\n",
+      "\n",
+      "\n",
+      "Finished modeling.\n",
+      "\n",
+      "\n",
+      "\n",
+      "Predicting...\n",
+      "\n",
+      "\n",
+      "\n",
+      "Predictions created.\n",
+      "\n",
+      "\n",
+      "\n",
+      "Evaluating results...\n",
+      "\n",
+      "\n",
+      "Evaluation Metrics:\n",
+      "accuracy: 0.37258347978910367\n",
+      "recall: 0.0\n",
+      "precision: 0.0\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/homebrew/Caskroom/miniconda/base/envs/dsc2venv/lib/python3.9/site-packages/sklearn/metrics/_classification.py:1565: UndefinedMetricWarning: Precision is ill-defined and being set to 0.0 due to no predicted samples. Use `zero_division` parameter to control this behavior.\n",
+      "  _warn_prf(average, modifier, f\"{metric.capitalize()} is\", len(result))\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAigAAAGzCAYAAAAFROyYAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8ekN5oAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAscUlEQVR4nO3dDXyN9f/H8c82GzZMlm3I0C1zk6LcFBWzpRHRnfw0JZUfCr8Uv4eI+kUkSm6qh1ApUqkfolDpxtz/9JMipKhlc7cNtbnZ9X98vv/HdX47s1ubznfb6/l4XM4513Wd6/qe61x23ud7cx0/x3EcAQAAsIi/rwsAAACQEwEFAABYh4ACAACsQ0ABAADWIaAAAADrEFAAAIB1CCgAAMA6BBQAAGAdAgoAALAOAQX4C9WvX1/69u3refzFF1+In5+fuS0pur2nnnpKSrs333xTGjZsKIGBgVK9evUiP//nn382x+L5558XW+j7omU6n9zXPXfu3L90v0BJI6Cg3NA/2PpH2p0qVaokl19+uQwaNEiSk5OlNPn444/LRAjJy44dO0yQu+SSS+S1116TV199tdweC6C8IqCg3Bk3bpz5dv7yyy9L27ZtZebMmdKmTRv5448//vKytG/fXv78809zWxT6oTx27Nhcl+n2Ro0aJaWZ1ihlZWXJiy++aILKnXfeeU7Hwjb6vuj7U172CxRHhWI9GyiFOnfuLC1btjT3H3jgAQkLC5MXXnhBPvroI+nVq1euzzlx4oSEhISUeFn8/f1NTU5JKunt+UJKSoq5PZemHZtVqFDBTOVlv0BxUIOCcq9Dhw7mdu/eveZWv7FXqVJF9uzZI7fccotUrVpVevfubZbpt/qpU6dK48aNTRCIiIiQhx56SI4ePeq1Tf2R8GeeeUYuuugiCQ4Olptuukm2b99+1r7z6oOyfv16s+8LLrjABKNmzZqZ2gS3fNOnTzf3szdZ5dcH5T//+Y8JZtWqVTOvrWPHjrJu3bpcm8C++eYbGTZsmNSsWdPs+7bbbpODBw96rbtp0yaJi4uTCy+8UCpXriwNGjSQ+++/v1DHe8aMGeb4VaxYUWrXri0DBw6U1NRUr346Y8aMMfe1DPn1qSnoWLi0iUibi3Sf11xzjWzcuDHXZqXbb79datSoYd5bDbH//ve/i9TXZcqUKVKvXj1zTG644Qb57rvvvNbNrS+IPtZmxvnz58sVV1xh9t2iRQv58ssvz9rXb7/9Zo6znnf6WvQ4vv766wWWMb/9fvjhh9KkSRPP9lasWFFi+wWKg0iNck+DiNKaFNfp06fNB/D1119vPng0ZCgNI/pBft9998kjjzxiQo02FWkA0A927dCpRo8ebQKKhgydtmzZIrGxsXLy5MkCy7Ny5Urp0qWL1KpVSx599FGJjIyUH374QZYuXWoeaxmSkpLMetpUVRANRu3atTPh5PHHHzdlfOWVV+TGG2+UNWvWSKtWrbzWHzx4sAlGGhL0w1cDmX6QLVy40FO7oa9Fw8OIESNMLYeu98EHHxTqg1KbY2JiYmTAgAGyc+dO08SmgcE9frq/N954QxYvXmyWaaDSgJabwhyLt99+W44dO2bW1Q/liRMnSo8ePeSnn37yvF96jK677jqpU6eOeU0azN59913p3r27vP/++yakFUTLrPvRwJWRkWECpYbfbdu2mQ/2/Oj7oMdXzykNABribr75ZtmwYYMJD0r7SbVu3doTLPT4L1++XPr16yfp6ekyZMgQKaqvv/7avG9///vfTRB/6aWXpGfPnrJv3z7P/4fzsV+gUBygnJgzZ46jp/yqVaucgwcPOvv373cWLFjghIWFOZUrV3Z+/fVXs15CQoJZb8SIEV7P/+qrr8z8+fPne81fsWKF1/yUlBQnKCjIiY+Pd7Kysjzr/fOf/zTr6fZdn3/+uZmnt+r06dNOgwYNnHr16jlHjx712k/2bQ0cONA8Lzc6f8yYMZ7H3bt3N+XZs2ePZ15SUpJTtWpVp3379mcdn5iYGK99DR061AkICHBSU1PN48WLF5v1Nm7c6BSFe1xiY2OdM2fOeOa//PLLZnuvv/66Z56WX+fp+1SQvI7F3r17zXx9f48cOeKZ/9FHH5n5S5Ys8czr2LGj07RpUycjI8MzT49B27Ztncsuuyzf/bv7yX4OqfXr15v5evxyvq7s9LFOmzZt8sz75ZdfnEqVKjm33XabZ16/fv2cWrVqOYcOHfJ6/t133+2EhoY6f/zxh1d59P0saL/6fuzevdsz79tvvzXzp02bVuT9AiWNJh6UO/rtXb8F1q1bV+6++27zDV2/reu35+z0G352ixYtktDQUOnUqZMcOnTIM2l1vG7j888/N+utWrXK1JRoTUT2avXCfNPUmhitldF1c/a/OJdhomfOnJFPP/3U1ARcfPHFnvlaO3PPPfeYb9D6LTi7Bx980GtfWvui2/nll1/MY7dcWqNz6tSpQpfFPS762rTvjat///6mdmfZsmVyPtx1112mRij761Fag6KOHDkin332memIqzUg7vt6+PBhU4u2a9cu08RRED3G2c+ha6+91tROaSfegmgnbT2PXFFRUdKtWzf55JNPzLHXPKE1OV27djX3s59/Wsa0tDRTS3cu/xe06culNVX6XrjH5nztFygMmnhQ7mifBR1erJ0Gtepd2/2zf2AqXab9R7LTDyr9gxweHp5vx073g/yyyy7zWq6hKPsHZX7NTW61fnFp3xEdnaSvMadGjRqZPjX79+83fQqyfzhm55bZ7WejfSu0GUCbarTPhTYV6YezBh5tnsiLe1xyliUoKMiEJ3d5SSvo9ezevdt8+D755JNmyuu9zRlgc8r5fis9z7SpqCB5PVffO30P9fzUfjralyavIdfu+VecY+MeH/fY6L7Px36BwiCgoNzRb7buKJ686AdtztCiH+YaTrQzY240gJQFAQEBuc7//1aB/6/Jee+990wn2yVLlphv+dqBcvLkyWae1iaVptej76t67LHHTK1Abi699FLxJbeMf/vb3yQhISHXdfLqp1MSx6ak9wsUBgEFKCStCtdmCu1MqaM08qKjONwal+zNKvptNOdon9z2oXT0h1a/56WwzT0amrSDr3ZGzW3UioYwbeo6F9pxUqd//etfpiOqjnRasGCBGbqd33HRsmQ/Ltrso81a+b3e/BT3CqluWbTD7LmWwX2/c/rxxx/NqKRzfa6+d27w1U6s2txTnDIWle7bF/sFFH1QgELSPgr6h/rpp58+a5mO+nGHyuofcv2wmzZtmuebqNLRKQW5+uqrzZBdXTf70FuVfVvuNVlyrpPbN2QdcaPXeNGRNi4dmaGhQkcpaZ+DotCQlb0sqnnz5uY2MzMzz+fpcdHmHB0pkv35s2fPNk1n8fHxci4KeyzyorVi2kylI5t+//33s5bnHGKdFx2um72vio7A0eHiOry7IImJiV59ObTZTd8zfe/0PdRJm9W0P0jOoctFKWNR+Wq/gKIGBSgk7XuhQ1XHjx8vW7duNR8eGkT02692oNVhpXodDf3Wqc0Fup4OF9Zhxtr5VYdm6nVD8qM1Gjq0Vjsl6oe+DmfWDq1a26FDYbU5RbkdKnVYqjZL6AeJdvjNjQ531mG4GkZ0OKn2r9EPYw0TOuS2qObNm2eGwerQW63x0Y6lejl6DTr6WvOix2XkyJGm74oOob311ltNbYpuS69Nos0I56IoxyK/fkl6fJo2bWo67WqtioY4DQ6//vqrfPvttwVuQ5uBdBvauVqPrYZMHaqrQ7sLon2OtOzZhxmr7FfInTBhgumIrR1vtYzR0dGmg68GG63Z0/vng6/2CzDMGOWGO4y2oOGxOgw4JCQkz+Wvvvqq06JFCzOsVIfq6vDUxx9/3Azddekw2rFjx5rhmbrejTfe6Hz33Xdm+HB+w4xdX3/9tdOpUyezfS1Ls2bNvIZ+6nDkwYMHOzVr1nT8/Py8hpDmHGastmzZ4sTFxTlVqlRxgoODnZtuuslZu3ZtoY5PzjLqtnr16uVERUU5FStWdMLDw50uXbp4DZPNjw4rbtiwoRMYGOhEREQ4AwYMOGtIdVGGGed1LNzhtpMmTTrrObkdIx2Gfe+99zqRkZGmbHXq1DGv67333st3/9n3M3nyZKdu3brmuLRr184M283tdeUsiw6Vfuutt8yQZn3uVVddddY5oZKTk826ug8to5ZVh0jrOZmzPIUZZqzbyinnOVrY/QIlzU//8XVIAoDSSpvOtFlu0qRJpubsXPrQ6MXd9IJ/AP6HPigAAMA6BBQAAGAdAgoAALAOfVAAAIB1qEEBAADWIaAAAADrlMoLtenvQyQlJZlLMBf3MtcAAOCvob1K9OKOtWvXPuv3zspEQNFwcq6/HwIAAHxLf84h5y/Gl4mAojUn7gss6u+IAAAA30hPTzcVDO7neJkLKG6zjoYTAgoAAKVLYbpn0EkWAABYh4ACAACsQ0AB8vDUU0+ZasjsU8OGDb3WSUxMlA4dOkhISIhpbmzfvr38+eefnuX6k/SdOnWS6tWrS1hYmDz44INy/PhxH7waAChdCChAPho3biy///67Z/r666+9wsnNN98ssbGxsmHDBtm4caMMGjTIM3ROR5vFxMTIpZdeKuvXr5cVK1bI9u3bpW/fvj58RQBQOpTKTrLAX6VChQoSGRmZ67KhQ4fKI488IiNGjPDMu+KKKzz3ly5dKoGBgTJ9+nRPaJk1a5Y0a9ZMdu/ebYILACB31KAA+di1a5e5oNDFF18svXv3ln379pn5KSkpplYkPDxc2rZtKxEREXLDDTd41bBkZmZKUFCQ18WIKleubG6zrwcAOBsBBchDq1atZO7cuaZpZubMmbJ3715p166duQriTz/95Omn0r9/f7PO1VdfLR07djShRmnflAMHDsikSZPk5MmTcvToUU9tizYXAQDyRkAB8tC5c2e54447TJNMXFycfPzxx5Kamirvvvuu+bkF9dBDD8l9990nV111lUyZMsU08bz++uue/ivz5s2TyZMnS3BwsGkqatCggaltKegSzwBQ3vFXEigkHYlz+eWXm/4jtWrVMvOio6O91mnUqJGnGUjdc889phblt99+k8OHD5sal4MHD5omIwBA3ggoQCHp8OA9e/aYcFK/fn3TN2Xnzp1e6/z4449Sr169s56rtSZVqlSRhQsXSqVKlczQYwBA3hjFA+Thsccek65du5rAoUOGx4wZIwEBAdKrVy9zTZThw4ebeVdeeaU0b97cNOfs2LFD3nvvPc82Xn75ZdOJVsPJypUrzXMmTJhgamMAAHkjoAB5+PXXX00Y0aaZmjVryvXXXy/r1q0z99WQIUMkIyPDDDc+cuSICSoaQi655BLPNvT6KBpitPZFL/L2yiuvSJ8+fXz4qgCgdPBzHMeRUvhriKGhoZKWlsaPBQIAUAY/v+mDAgAArEMTD4qt/ohlvi4CLPPzhHhfFwFAKUcNCgAAsA4BBQAAWIeAAgAArENAAQAA1iGgAAAA6xBQAACAdQgoAADAOgQUAABgHQIKAACwDgEFAABYh4ACAACsQ0ABAADWIaAAAADrEFAAAIB1CCgAAMA6BBQAAGAdAgoAALAOAQUAAFiHgAIAAKxDQAEAANYhoAAAAOsQUAAAgHUIKAAAwDoEFAAAYB0CCgAAsA4BBQAAWIeAAgAArENAAQAA1iGgAAAA6xBQAACAdQgoAADAOgQUAABgHQIKAACwDgEFAABYh4ACAACsQ0ABAADWIaAAAADrEFAAAEDpDihPPfWU+Pn5eU0NGzb0LM/IyJCBAwdKWFiYVKlSRXr27CnJycle29i3b5/Ex8dLcHCwhIeHy/Dhw+X06dMl94oAAECpV6GoT2jcuLGsWrXqfxuo8L9NDB06VJYtWyaLFi2S0NBQGTRokPTo0UO++eYbs/zMmTMmnERGRsratWvl999/l3vvvVcCAwPl2WefLanXBAAAyltA0UCiASOntLQ0mT17trz99tvSoUMHM2/OnDnSqFEjWbdunbRu3Vo+/fRT+f77703AiYiIkObNm8vTTz8tTzzxhKmdCQoKKplXBQAAylcflF27dknt2rXl4osvlt69e5smG7V582Y5deqUxMTEeNbV5p+oqChJTEw0j/W2adOmJpy44uLiJD09XbZv357nPjMzM8062ScAAFB2FSmgtGrVSubOnSsrVqyQmTNnyt69e6Vdu3Zy7NgxOXDggKkBqV69utdzNIzoMqW32cOJu9xdlpfx48ebJiN3qlu3blGKDQAAynITT+fOnT33mzVrZgJLvXr15N1335XKlSvL+TJy5EgZNmyY57HWoBBSAAAou4o1zFhrSy6//HLZvXu36Zdy8uRJSU1N9VpHR/G4fVb0NueoHvdxbv1aXBUrVpRq1ap5TQAAoOwqVkA5fvy47NmzR2rVqiUtWrQwo3FWr17tWb5z507TR6VNmzbmsd5u27ZNUlJSPOusXLnSBI7o6OjiFAUAAJTXJp7HHntMunbtapp1kpKSZMyYMRIQECC9evUyfUP69etnmmJq1KhhQsfgwYNNKNERPCo2NtYEkT59+sjEiRNNv5NRo0aZa6doLQkAAECRA8qvv/5qwsjhw4elZs2acv3115shxHpfTZkyRfz9/c0F2nTkjY7QmTFjhuf5GmaWLl0qAwYMMMElJCREEhISZNy4cbwbAADAw89xHEdKGe0kqzU2eu0V+qP4Xv0Ry3xdBFjm5wnxvi4CgFL++c1v8QAAAOsQUAAAgHUIKAAAwDoEFAAAYB0CCgAAsA4BBQAAWIeAAgAArENAAQAA1iGgAAAA6xBQAACAdQgoAADAOgQUAABgHQIKAACwDgEFAABYh4ACAACsQ0ABAADWIaAAAADrEFAAAIB1CCgAAMA6BBQAAGAdAgoAALAOAQUAAFiHgAIAAKxDQAEAANYhoAAAAOsQUAAAgHUIKAAAwDoEFAAAYB0CCgAAsA4BBQAAWIeAAgAArENAAQAA1iGgAAAA6xBQAACAdQgoAADAOgQUAABgHQIKAACwDgEFAABYh4ACAACsQ0ABAADWIaAAAADrEFAAAIB1CCgAAMA6BBQAAGAdAgoAALAOAQUAAFiHgAIAAKxDQAEAANYhoAAAAOsQUAAAgHUIKAAAoGwFlAkTJoifn58MGTLEMy8jI0MGDhwoYWFhUqVKFenZs6ckJyd7PW/fvn0SHx8vwcHBEh4eLsOHD5fTp08XpygAAKAMOeeAsnHjRnnllVekWbNmXvOHDh0qS5YskUWLFsmaNWskKSlJevTo4Vl+5swZE05Onjwpa9eulXnz5sncuXNl9OjRxXslAACgfAeU48ePS+/eveW1116TCy64wDM/LS1NZs+eLS+88IJ06NBBWrRoIXPmzDFBZN26dWadTz/9VL7//nt56623pHnz5tK5c2d5+umnZfr06Sa0AAAAnFNA0SYcrQWJiYnxmr9582Y5deqU1/yGDRtKVFSUJCYmmsd627RpU4mIiPCsExcXJ+np6bJ9+/Zc95eZmWmWZ58AAEDZVaGoT1iwYIFs2bLFNPHkdODAAQkKCpLq1at7zdcwosvcdbKHE3e5uyw348ePl7Fjxxa1qAAAoDzUoOzfv18effRRmT9/vlSqVEn+KiNHjjTNR+6k5QAAAGVXkQKKNuGkpKTI1VdfLRUqVDCTdoR96aWXzH2tCdF+JKmpqV7P01E8kZGR5r7e5hzV4z5218mpYsWKUq1aNa8JAACUXUUKKB07dpRt27bJ1q1bPVPLli1Nh1n3fmBgoKxevdrznJ07d5phxW3atDGP9Va3oUHHtXLlShM6oqOjS/K1AQCA8tAHpWrVqtKkSROveSEhIeaaJ+78fv36ybBhw6RGjRomdAwePNiEktatW5vlsbGxJoj06dNHJk6caPqdjBo1ynS81ZoSAACAIneSLciUKVPE39/fXKBNR9/oCJ0ZM2Z4lgcEBMjSpUtlwIABJrhowElISJBx48aVdFEAAEAp5ec4jiOljA4zDg0NNR1m6Y/ie/VHLPN1EWCZnyfE+7oIAEr55ze/xQMAAKxDQAEAANYhoAAAAOsQUAAAgHUIKAAAwDoEFAAAYB0CCgAAsA4BBQAAWIeAAgAArENAAQAA1iGgAAAA6xBQAACAdQgoAADAOgQUAABgHQIKAACwDgEFAABYh4ACAACsQ0ABAADWIaAAAADrEFAAAIB1CCgAAMA6BBQAAGAdAgoAALAOAQUAAFiHgAIAAKxDQAEAANYhoAAAAOsQUAAAgHUIKAAAwDoEFAAAYB0CCgAAsA4BBQAAWIeAAgAArENAAQAA1iGgAAAA6xBQAACAdQgoAADAOgQUAABgHQIKAACwDgEFAABYh4ACAACsQ0ABAADWIaAAAADrEFAAAIB1CCgAAMA6BBQAAGAdAgoAALAOAQUAAFiHgAIAAKxDQAEAANYhoAAAgNIdUGbOnCnNmjWTatWqmalNmzayfPlyz/KMjAwZOHCghIWFSZUqVaRnz56SnJzstY19+/ZJfHy8BAcHS3h4uAwfPlxOnz5dcq8IAACUr4By0UUXyYQJE2Tz5s2yadMm6dChg3Tr1k22b99ulg8dOlSWLFkiixYtkjVr1khSUpL06NHD8/wzZ86YcHLy5ElZu3atzJs3T+bOnSujR48u+VcGAABKLT/HcZzibKBGjRoyadIkuf3226VmzZry9ttvm/tqx44d0qhRI0lMTJTWrVub2pYuXbqY4BIREWHWmTVrljzxxBNy8OBBCQoKKtQ+09PTJTQ0VNLS0kxNDnyr/ohlvi4CLPPzhHhfFwGAhYry+X3OfVC0NmTBggVy4sQJ09SjtSqnTp2SmJgYzzoNGzaUqKgoE1CU3jZt2tQTTlRcXJwpsFsLk5vMzEyzTvYJAACUXUUOKNu2bTP9SypWrCgPP/ywLF68WKKjo+XAgQOmBqR69epe62sY0WVKb7OHE3e5uywv48ePN4nLnerWrVvUYgMAgLIcUK644grZunWrrF+/XgYMGCAJCQny/fffy/k0cuRIUx3kTvv37z+v+wMAAL5VoahP0FqSSy+91Nxv0aKFbNy4UV588UW56667TOfX1NRUr1oUHcUTGRlp7uvthg0bvLbnjvJx18mN1tboBAAAyodiXwclKyvL9BHRsBIYGCirV6/2LNu5c6cZVqx9VJTeahNRSkqKZ52VK1eajjLaTAQAAFDkGhRtauncubPp+Hrs2DEzYueLL76QTz75xPQN6devnwwbNsyM7NHQMXjwYBNKdASPio2NNUGkT58+MnHiRNPvZNSoUebaKdSQAACAcwooWvNx7733yu+//24CiV60TcNJp06dzPIpU6aIv7+/uUCb1qroCJ0ZM2Z4nh8QECBLly41fVc0uISEhJg+LOPGjStKMQAAQBlX7Oug+ALXQbEL10FBTlwHBYDProMCAABwvhBQAACAdQgoAADAOgQUAABgHQIKAACwDgEFAABYh4ACAACsQ0ABAADWIaAAAADrEFAAAIB1CCgAAMA6BBQAAGAdAgoAALAOAQUAAFiHgAIAAKxDQAEAANYhoAAAAOsQUAAAgHUIKAAAwDoEFAAAYB0CCgAAsA4BBQAAWIeAAgAArENAAQAA1iGgAAAA6xBQAACAdQgoAADAOgQUAABgHQIKAACwDgEFAABYh4ACAACsQ0ABAADWIaAAAADrEFAAAIB1CCgAAMA6BBQAAGAdAgoAALAOAQUAAFiHgAIAAKxDQAEAANYhoAAAAOsQUAAAgHUIKAAAwDoEFAAAYB0CCgAAsA4BBQAAWIeAAgAArENAAQAA1iGgAAAA6xBQAACAdQgoAACgdAeU8ePHyzXXXCNVq1aV8PBw6d69u+zcudNrnYyMDBk4cKCEhYVJlSpVpGfPnpKcnOy1zr59+yQ+Pl6Cg4PNdoYPHy6nT58umVcEAADKV0BZs2aNCR/r1q2TlStXyqlTpyQ2NlZOnDjhWWfo0KGyZMkSWbRokVk/KSlJevTo4Vl+5swZE05Onjwpa9eulXnz5sncuXNl9OjRJfvKAABAqeXnOI5zrk8+ePCgqQHRINK+fXtJS0uTmjVryttvvy233367WWfHjh3SqFEjSUxMlNatW8vy5culS5cuJrhERESYdWbNmiVPPPGE2V5QUFCB+01PT5fQ0FCzv2rVqp1r8VFC6o9Y5usiwDI/T4j3dREAWKgon9/F6oOiO1A1atQwt5s3bza1KjExMZ51GjZsKFFRUSagKL1t2rSpJ5youLg4U+jt27fnup/MzEyzPPsEAADKrnMOKFlZWTJkyBC57rrrpEmTJmbegQMHTA1I9erVvdbVMKLL3HWyhxN3ubssr74vmrjcqW7duudabAAAUJYDivZF+e6772TBggVyvo0cOdLU1rjT/v37z/s+AQCA71Q4lycNGjRIli5dKl9++aVcdNFFnvmRkZGm82tqaqpXLYqO4tFl7jobNmzw2p47ysddJ6eKFSuaCQAAlA9FqkHR/rQaThYvXiyfffaZNGjQwGt5ixYtJDAwUFavXu2Zp8OQdVhxmzZtzGO93bZtm6SkpHjW0RFB2lkmOjq6+K8IAACUrxoUbdbRETofffSRuRaK22dE+4VUrlzZ3Pbr10+GDRtmOs5q6Bg8eLAJJTqCR+mwZA0iffr0kYkTJ5ptjBo1ymybWhIAAFDkgDJz5kxze+ONN3rNnzNnjvTt29fcnzJlivj7+5sLtOnoGx2hM2PGDM+6AQEBpnlowIABJriEhIRIQkKCjBs3jncEAAAU/zoovsJ1UOzCdVCQE9dBAeDT66AAAACcDwQUAABgHQIKAACwDgEFAABYh4ACAACsQ0ABAADWIaAAAADrEFAAAIB1CCgAAMA6BBQAAGAdAgoAALAOAQUAAFiHgAIAAKxDQAEAANYhoAAAAOsQUAAAgHUIKAAAwDoEFAAAYB0CCgAAsA4BBQAAWIeAAgAArENAAQAA1iGgAAAA6xBQAACAdQgoAADAOgQUAABgHQIKAACwDgEFAABYh4ACAACsQ0ABAADWIaAAAADrEFAAAIB1CCgAAMA6BBQAAGAdAgoAALAOAQUAAFiHgAIAAKxDQAEAANYhoAAAAOsQUAAAgHUIKAAAwDoEFAAAYB0CCgAAsA4BBQAAWIeAAgAArENAAQAA1iGgAAAA6xBQAACAdQgoAADAOgQUAABgHQIKAAAo/QHlyy+/lK5du0rt2rXFz89PPvzwQ6/ljuPI6NGjpVatWlK5cmWJiYmRXbt2ea1z5MgR6d27t1SrVk2qV68u/fr1k+PHjxf/1QAAgPIZUE6cOCFXXnmlTJ8+PdflEydOlJdeeklmzZol69evl5CQEImLi5OMjAzPOhpOtm/fLitXrpSlS5ea0PPggw8W75UAAIAyo0JRn9C5c2cz5UZrT6ZOnSqjRo2Sbt26mXlvvPGGREREmJqWu+++W3744QdZsWKFbNy4UVq2bGnWmTZtmtxyyy3y/PPPm5qZnDIzM83kSk9PL2qxAQBAee2DsnfvXjlw4IBp1nGFhoZKq1atJDEx0TzWW23WccOJ0vX9/f1NjUtuxo8fb7bjTnXr1i3JYgMAgLIcUDScKK0xyU4fu8v0Njw83Gt5hQoVpEaNGp51cho5cqSkpaV5pv3795dksQEAQGlv4vGFihUrmgkAAJQPJVqDEhkZaW6Tk5O95utjd5nepqSkeC0/ffq0GdnjrgMAAMq3Eg0oDRo0MCFj9erVXh1atW9JmzZtzGO9TU1Nlc2bN3vW+eyzzyQrK8v0VQEAAChyE49er2T37t1eHWO3bt1q+pBERUXJkCFD5JlnnpHLLrvMBJYnn3zSjMzp3r27Wb9Ro0Zy8803S//+/c1Q5FOnTsmgQYPMCJ/cRvAAAIDyp8gBZdOmTXLTTTd5Hg8bNszcJiQkyNy5c+Xxxx8310rR65poTcn1119vhhVXqlTJ85z58+ebUNKxY0czeqdnz57m2ikAAADKz9GLl5Qy2mykw411RI9ejRa+VX/EMl8XAZb5eUK8r4sAoJR/fvNbPAAAwDoEFAAAYB0CCgAAsA4BBQAAWIeAAgAArENAAQAA1iGgAAAA6xBQAACAdQgoAADAOgQUAABgHQIKAACwDgEFAABYh4ACAACsQ0ABAADWIaAAAADrEFAAAIB1CCgAAMA6BBQAAGAdAgoAALAOAQUAAFiHgAIAAKxDQAEAANYhoAAAAOsQUAAAgHUIKAAAwDoEFAAAYB0CCgAAsA4BBQAAWIeAAgAArENAAQAA1iGgAAAA6xBQAACAdQgoAADAOgQUAABgHQIKAACwDgEFAABYh4ACAACsQ0ABAADWIaAAAADrEFAAAIB1CCgAAMA6BBQAAGAdAgoAALAOAQUAAFiHgAIAAKxDQAEAANYhoAAAAOsQUAAAgHUIKAAAwDoEFAAAYB2fBpTp06dL/fr1pVKlStKqVSvZsGGDL4sDAADKe0BZuHChDBs2TMaMGSNbtmyRK6+8UuLi4iQlJcVXRQIAAOU9oLzwwgvSv39/ue+++yQ6OlpmzZolwcHB8vrrr/uqSAAAwBIVfLHTkydPyubNm2XkyJGeef7+/hITEyOJiYlnrZ+ZmWkmV1pamrlNT0//i0qM/GRl/uHrIsAy/N8EkN/fBsdxxMqAcujQITlz5oxERER4zdfHO3bsOGv98ePHy9ixY8+aX7du3fNaTgDnJnSqr0sAwGaHDx+W0NBQ+wJKUWlNi/ZXcaWmpkq9evVk3759Bb5A4K/6VqCBef/+/VKtWjVfFwcwOC9hG20BiYqKkho1ahS4rk8CyoUXXigBAQGSnJzsNV8fR0ZGnrV+xYoVzZSThhP+08Emej5yTsI2nJewjXbrKHAd8YGgoCBp0aKFrF692jMvKyvLPG7Tpo0vigQAACzisyYebbJJSEiQli1byrXXXitTp06VEydOmFE9AACgfPNZQLnrrrvk4MGDMnr0aDlw4IA0b95cVqxYcVbH2dxoc49ePyW3Zh/AFzgnYSPOS5Tmc9LPKcxYHwAAgL8Qv8UDAACsQ0ABAADWIaAAAADrEFAAAIB1CCiA5b744gvx8/MzV1AGfKV+/frmchDAX4WAgnKlb9++5sN+woQJXvM//PBDMx843/QHUfVK2vHx8b4uCmA1AgrKnUqVKslzzz0nR48eLdFf6AYKY/bs2TJ48GD58ssvJSkpydfFAaxFQEG5ExMTY37zSX8lOy/vv/++NG7c2FxMSKu2J0+e7LVc5z399NNy7733mt84efDBB2Xu3LlSvXp1Wbp0qVxxxRUSHBwst99+u/zxxx8yb94885wLLrhAHnnkEfNr3q4333zTXFG5atWqplz33HOPpKSknNdjAN84fvy4LFy4UAYMGGBqUPScydmUpz/5oeeDnj9t27aVnTt3em1j5syZcskll5ifDNHzTM+f7HQbr7zyinTp0sVso1GjRqbWZvfu3XLjjTdKSEiI2e6ePXs8z9H73bp1MxfKrFKlilxzzTWyatWqPF/H/fffb7af3alTpyQ8PNwEMKBE6IXagPIiISHB6datm/PBBx84lSpVcvbv32/mL168WC9YaO5v2rTJ8ff3d8aNG+fs3LnTmTNnjlO5cmVz66pXr55TrVo15/nnn3d2795tJl0eGBjodOrUydmyZYuzZs0aJywszImNjXXuvPNOZ/v27c6SJUucoKAgZ8GCBZ5tzZ492/n444+dPXv2OImJiU6bNm2czp07e5Z//vnnpmxHjx79S48VSp6+1y1btjT39Vy45JJLnKysLK/3uVWrVs4XX3xhzpd27do5bdu29Txfz1s9x6ZPn27OzcmTJzsBAQHOZ5995llHt1GnTh1n4cKFZp3u3bs79evXdzp06OCsWLHC+f77753WrVs7N998s+c5W7dudWbNmuVs27bN+fHHH51Ro0aZ/x+//PKL1zk/ZcoUc/+bb74x+01KSvIqW0hIiHPs2LHzfBRRXhBQUC4DitI/0vfff/9ZAeWee+4xISO74cOHO9HR0V5/rPUPf3YaUHQbGlZcDz30kBMcHOz1RzsuLs7Mz8vGjRvNdtznEFDKDg0bU6dONfdPnTrlXHjhheb9zf4+r1q1yrP+smXLzLw///zT8/z+/ft7bfOOO+5wbrnlFs9jXV8DhktDr87TcOR65513TADJT+PGjZ1p06blGlCU/n947rnnPI+7du3q9O3bt4hHBMgbTTwot7Qfija9/PDDD17z9fF1113nNU8f79q1y6tpRqvhc9Iqda1+d2mVuTbtaLV59nnZm3A2b94sXbt2laioKNPMc8MNN5j5+/btK6FXChtoU82GDRukV69e5nGFChXMb5LlbBJp1qyZ536tWrXMrXu+5HVu5jyHs2/D/X2zpk2bes3LyMiQ9PR0T9PTY489ZpqDtJlSz1fdZn7n4AMPPCBz5swx95OTk2X58uWm6QcoKQQUlFvt27eXuLg4GTly5Dk9X9vycwoMDDyrP0Bu87Kyssx9/QVvLYP2Y5k/f75s3LhRFi9ebJbR8bZs0SBy+vRpqV27tgknOml/Eu3vlJaW5lkv+/nijixzz5fCym0b+W1Xw4med88++6x89dVXsnXrVhNo8jsHtf/VTz/9ZPq3vPXWW9KgQQNp165dkcoJWPlrxoANdLix/pK2djZ06bfIb775xms9fXz55Zeb4aElaceOHXL48GFTjrp165p5mzZtKtF9wPc0mLzxxhums3VsbKzXsu7du8s777wjDRs2LHA77rmZkJDgmaePo6Oji1U+3YYOwb/ttts8NSo///xzvs8JCwszZddaFA0p9913X7HKAOREQEG5pt8Se/fuLS+99JJn3j/+8Q8zikFH6WgVvP7xffnll2XGjBklvn9t1tHRGNOmTZOHH35YvvvuO7NflC06skuHtffr109CQ0O9lvXs2dPUrkyaNKnA7QwfPlzuvPNOueqqq8xotCVLlsgHH3yQ74ibwrjsssvMdrSpUWtXnnzyyULV2mgzj47m0abP7KEJKAk08aDcGzdunNcf46uvvlreffddWbBggTRp0kRGjx5t1tFvmCWtZs2aZqjpokWLzLdgrUl5/vnnS3w/8C0NIBoocoYTN6Bordl///vfArejNRYvvviiOUd0GLwOJ9YaDB0+XBwvvPCCGQKvw481pGizo/4/KIi+Ju0no+tr0xVQkvy0p2yJbhEAUC5oU1CdOnVMSOrRo4evi4MyhiYeAECRaI3joUOHTJ8aHfVz6623+rpIKIMIKACAItHhxzpq56KLLjJNlDoiCShpNPEAAADr0EkWAABYh4ACAACsQ0ABAADWIaAAAADrEFAAAIB1CCgAAMA6BBQAAGAdAgoAABDb/B+WhqQEgivu5wAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "Finished evaluation.\n",
+      "\n",
+      "\n",
+      "\n",
+      "Pipeline execution completed.\n",
+      "\n",
+      "\n",
+      "Done!\n"
+     ]
+    }
+   ],
+   "source": [
+    "offline_detection.pipeline(\n",
+    "    msg_callback=msg_callback,\n",
+    "    report_callback=handle_report,\n",
+    "    verb=False\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "dsc2venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.25"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/offline-detection/main.py
+++ b/offline-detection/main.py
@@ -8,6 +8,17 @@
 #
 # --------------------------------------------------------------------------------------------------------
 
+# --------------------------------------------------------------------------------------------------------
+# Utilities
+
+def verb_aware_print(msg, verb=True):
+    if verb and msg: print(msg)
+
+def noop_callback(**kwargs):
+    pass
+
+# --------------------------------------------------------------------------------------------------------
+
 # Imports and constants
 
 import kagglehub
@@ -116,34 +127,89 @@ def evaluate(target, y_pred):
     return metrics
 
 
-def pipeline(verb=VERBOSE):
-    if verb: print("\n\nStarting pipeline execution...\n")
+def pipeline(msg_callback=noop_callback, report_callback=noop_callback, verb=VERBOSE):
+    """
+    Pipeline function that executes the entire workflow from data loading to evaluation, while providing updates through callbacks (e.g.: for the Streamlit app).
+
+    Parameters
+    ----------
+
+    msg_callback : callable
+        A function that handles messages at the call site. It should accept a `msg` argument for the message string and an optional `end` argument to indicate if it's the end of the pipeline.
+
+    report_callback : callable
+        A function that handles a report in form of a dictionary. It should accept a `news` argument for the report.
+
+    verb : bool
+        Whether to print verbose messages.
+    """
+
+    msg = "\n\nStarting pipeline execution...\n"
+    verb_aware_print(msg, verb)
+    msg_callback(msg=msg)
+
 
     # DATA HANDLING
+
+    msg = "\n\nPreprocessing...\n"
+    verb_aware_print(msg, verb)
+    msg_callback(msg=msg)
 
     data, target = load_data()
     cleaned_data = clean_data(data)
     X = preprocess_data(cleaned_data)
 
+    msg = "\n\nFinished preprocessing.\n"
+    verb_aware_print(msg, verb)
+    msg_callback(msg=msg)
+
     # MODELING
+
+    msg = "\n\nObtaining model...\n"
+    verb_aware_print(msg, verb)
+    msg_callback(msg=msg)
 
     model = modeling(X)
 
+    msg = "\n\nFinished modeling.\n"
+    verb_aware_print(msg, verb)
+    msg_callback(msg=msg)
+
     # PREDICTION
+
+    msg = "\n\nPredicting...\n"
+    verb_aware_print(msg, verb)
+    msg_callback(msg=msg)
 
     predictions = predict(model, X)
 
+    msg = "\n\nPredictions created.\n"
+    verb_aware_print(msg, verb)
+    msg_callback(msg=msg)
+
     # EVALUATION
 
+    msg = "\n\nEvaluating results...\n"
+    verb_aware_print(msg, verb)
+    msg_callback(msg=msg)
+
     metrics = evaluate(target, predictions)
-    
+
     print("\nEvaluation Metrics:")
     for metric_name, metric_value in metrics.items():
         print(f"{metric_name}: {metric_value}")
 
+    to_report = {
+        "predictions": predictions,
+        "metrics": metrics,
+    }
 
-    if verb: print("\n\nPipeline execution completed.\n\n")
+    report_callback(news=to_report)
 
-
-# Execute the pipeline
-pipeline()
+    msg = "\n\nFinished evaluation.\n"
+    verb_aware_print(msg, verb)
+    msg_callback(msg=msg)
+    
+    msg = "\n\nPipeline execution completed.\n\n"
+    verb_aware_print(msg, verb)
+    msg_callback(msg=msg, end=True)


### PR DESCRIPTION
This pull request makes the `offline-detection/main.py` more intelligent. From now on, it supports callbacks that can be used in the Streamlit prototype on the `app` branch. The functionality remains in the main development file, which sends report that the app will be able to receive and display on the UI.

This is a preparation for #44.